### PR TITLE
fix: renamed command in help text

### DIFF
--- a/clmgr/args.py
+++ b/clmgr/args.py
@@ -18,9 +18,7 @@ def parse_args(args):
             prog, max_help_position=100, width=200
         )
 
-    parser = argparse.ArgumentParser(
-        prog="clmgr", formatter_class=formatter_class
-    )
+    parser = argparse.ArgumentParser(prog="clmgr", formatter_class=formatter_class)
 
     # Configure commandline options
     parser.add_argument(

--- a/clmgr/args.py
+++ b/clmgr/args.py
@@ -19,7 +19,7 @@ def parse_args(args):
         )
 
     parser = argparse.ArgumentParser(
-        prog="copyrightmgr", formatter_class=formatter_class
+        prog="clmgr", formatter_class=formatter_class
     )
 
     # Configure commandline options


### PR DESCRIPTION
The help text shows 'copyrightmgr'